### PR TITLE
Consistent popup

### DIFF
--- a/src/agenda/agenda.rs
+++ b/src/agenda/agenda.rs
@@ -278,7 +278,7 @@ impl Component for Agenda {
             html! {
                 <Popup
                     week_day = {week_day}
-                    event = {event}
+                    event = {event.clone()}
                     agenda_link = {ctx.link().clone()} />
             }
         );

--- a/src/agenda/agenda.rs
+++ b/src/agenda/agenda.rs
@@ -89,9 +89,15 @@ impl Component for Agenda {
             });
         }
         
+        // Disable slider if popup is open
+        let slider = slider::SliderManager::init(ctx.link().clone(), -20 * (now.date_naive().num_days_from_ce() - 730000));
+        if ctx.props().popup.is_some() {
+            slider.borrow_mut().disable();
+        }
+
         Self {
             selected_day: now.date_naive(),
-            slider: slider::SliderManager::init(ctx.link().clone(), -20 * (now.date_naive().num_days_from_ce() - 730000)),
+            slider,
             displayed_announcement,
             counter: AtomicUsize::new(0),
         }
@@ -159,6 +165,15 @@ impl Component for Agenda {
                 false
             }
         }
+    }
+
+    fn changed(&mut self, ctx: &Context<Self>, _old_props: &Self::Properties) -> bool {
+        if ctx.props().popup.is_some() {
+            self.slider.borrow_mut().disable();
+        } else {
+            self.slider.borrow_mut().enable();
+        }
+        true
     }
 
     fn view(&self, ctx: &Context<Self>) -> Html {

--- a/src/event/event.rs
+++ b/src/event/event.rs
@@ -90,11 +90,11 @@ impl Component for EventComp {
         let percent_height = 100.0 / day_sec_count * (ctx.props().event.end_unixtime - ctx.props().event.start_unixtime) as f64;
 
         // Render
-        let event1 = ctx.props().event.clone();
+        let eid = ctx.props().event.start_unixtime;
         let week_day = ctx.props().week_day;
         template_html!(
             "src/event/event.html",
-            onclick = { ctx.props().agenda_link.callback(move |_| AgendaMsg::AppMsg(AppMsg::SetPage(Page::Popup(PopupState::Opened{ week_day, event: event1.clone(), popup_size: None })))) },
+            onclick = { ctx.props().agenda_link.callback(move |_| AgendaMsg::AppMsg(AppMsg::SetPage(Page::Event { eid } ))) },
             teachers = { ctx.props().event.teachers.join(", ")},
             opt_location = location,
             bg_color = {bg_color.clone()},

--- a/src/event/event.rs
+++ b/src/event/event.rs
@@ -94,7 +94,7 @@ impl Component for EventComp {
         let week_day = ctx.props().week_day;
         template_html!(
             "src/event/event.html",
-            onclick = { ctx.props().agenda_link.callback(move |_| AgendaMsg::OpenPopup { week_day, event: event1.clone() }) },
+            onclick = { ctx.props().agenda_link.callback(move |_| AgendaMsg::AppMsg(AppMsg::OpenPopup { week_day, event: event1.clone() })) },
             teachers = { ctx.props().event.teachers.join(", ")},
             opt_location = location,
             bg_color = {bg_color.clone()},

--- a/src/event/event.rs
+++ b/src/event/event.rs
@@ -94,7 +94,7 @@ impl Component for EventComp {
         let week_day = ctx.props().week_day;
         template_html!(
             "src/event/event.html",
-            onclick = { ctx.props().agenda_link.callback(move |_| AgendaMsg::AppMsg(AppMsg::OpenPopup { week_day, event: event1.clone() })) },
+            onclick = { ctx.props().agenda_link.callback(move |_| AgendaMsg::AppMsg(AppMsg::SetPage(Page::Popup(PopupState::Opened{ week_day, event: event1.clone(), popup_size: None })))) },
             teachers = { ctx.props().event.teachers.join(", ")},
             opt_location = location,
             bg_color = {bg_color.clone()},

--- a/src/main.rs
+++ b/src/main.rs
@@ -252,7 +252,6 @@ impl Component for App {
                 let history = window().history().expect("Failed to access history");
                 let document = window().doc();
                 if let Page::Event { .. } = &page {
-                    //self.slider.borrow_mut().disable();
                     if let Some(day_el) = document.get_element_by_id("day0") {
                         let rect = day_el.get_bounding_client_rect();
                         self.event_popup_size = Some((width() as f64 - rect.width() - 2.0 * rect.left()) as usize)
@@ -275,7 +274,6 @@ impl Component for App {
                     return true;
                 }
                 if matches!(&page, Page::Agenda) {
-                    //self.slider.borrow_mut().enable();
                     self.event_closing = false;
                 }
                 let (data, title) = match &page {

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,6 +102,10 @@ impl Component for App {
                 Some("change-password") => link2.send_message(Msg::SilentSetPage(Page::ChangePassword)),
                 Some("change-email") => link2.send_message(Msg::SilentSetPage(Page::ChangeEmail)),
                 Some("change-group") => link2.send_message(Msg::SilentSetPage(Page::ChangeGroup)),
+                Some(event) if event.starts_with("event/") => {
+                    let eid = event[6..].parse().unwrap_or_default();
+                    link2.send_message(Msg::SilentSetPage(Page::Event { eid }))
+                }
                 Some(survey) if survey.starts_with("survey/") => link2.send_message(Msg::SilentSetPage(Page::Survey { sid: survey[7..].to_string() })),
                 _ if e.state().is_null() => link2.send_message(Msg::SilentSetPage(Page::Agenda)),
                 _ => alert(format!("Unknown pop state: {:?}", e.state())),
@@ -128,6 +132,15 @@ impl Component for App {
             "/change-password" => Page::ChangePassword,
             "/change-email" => Page::ChangeEmail,
             "/change-group" => Page::ChangeGroup,
+            event if event.starts_with("/event/") => {
+                let eid = event[7..].parse().unwrap_or_default();
+                let link2 = ctx.link().clone();
+                wasm_bindgen_futures::spawn_local(async move {
+                    sleep(Duration::from_millis(100)).await;
+                    link2.send_message(Msg::SetPage(Page::Event { eid }));
+                });
+                Page::Agenda
+            }
             survey if survey.starts_with("/survey/") => Page::Survey { sid: survey[8..].to_string() },
             "/agenda" => match window().location().hash() { // For compatibility with old links
                 Ok(hash) if hash == "#settings" => Page::Settings,
@@ -237,9 +250,10 @@ impl Component for App {
             },
             Msg::SetPage(page) => {
                 let history = window().history().expect("Failed to access history");
+                let document = window().doc();
                 if let Page::Event { .. } = &page {
                     //self.slider.borrow_mut().disable();
-                    if let Some(day_el) = window().doc().get_element_by_id("day0") {
+                    if let Some(day_el) = document.get_element_by_id("day0") {
                         let rect = day_el.get_bounding_client_rect();
                         self.event_popup_size = Some((width() as f64 - rect.width() - 2.0 * rect.left()) as usize)
                     }
@@ -264,15 +278,17 @@ impl Component for App {
                     //self.slider.borrow_mut().enable();
                     self.event_closing = false;
                 }
-                match &page {
-                    Page::Settings => history.push_state_with_url(&JsValue::from_str("settings"), "Settings", Some("/settings")).unwrap(),
-                    Page::ChangePassword => history.push_state_with_url(&JsValue::from_str("change-password"), "Change password", Some("/change-password")).unwrap(),
-                    Page::ChangeEmail => history.push_state_with_url(&JsValue::from_str("change-email"), "Change email", Some("/change-email")).unwrap(),
-                    Page::ChangeGroup => history.push_state_with_url(&JsValue::from_str("change-group"), "Change group", Some("/change-group")).unwrap(),
-                    Page::Agenda => history.push_state_with_url(&JsValue::from_str("agenda"), "Agenda", Some("/agenda")).unwrap(),
-                    Page::Survey { sid } => history.push_state_with_url(&JsValue::from_str(&format!("survey/{sid}")), "Survey", Some(&format!("/survey/{sid}"))).unwrap(),
-                    Page::Event { eid } => history.push_state_with_url(&JsValue::from_str(&format!("event/{eid}")), "Event", Some(&format!("/event/{eid}"))).unwrap(),
-                }
+                let (data, title) = match &page {
+                    Page::Settings => (String::from("settings"), "Settings"),
+                    Page::ChangePassword => (String::from("change-password"), "Change password"),
+                    Page::ChangeEmail => (String::from("change-email"), "Change email"),
+                    Page::ChangeGroup => (String::from("change-group"), "Change group"),
+                    Page::Agenda => (String::from("agenda"), "Agenda"),
+                    Page::Survey { sid } => (format!("survey/{sid}"), "Survey"),
+                    Page::Event { eid } => (format!("event/{eid}"), "Event"),
+                };
+                history.push_state_with_url(&JsValue::from_str(&data), title, Some(&format!("/{data}"))).unwrap();
+                document.set_title(&format!("{}", title));
                 self.page = page;
                 true
             },

--- a/src/popup/popup.rs
+++ b/src/popup/popup.rs
@@ -67,7 +67,9 @@ impl Component for Popup {
     }
 
     fn view(&self, ctx: &Context<Self>) -> Html {
-        let onclick_close = ctx.props().agenda_link.callback(|_| AgendaMsg::AppMsg(AppMsg::ClosePopup));
+        let week_day = ctx.props().week_day;
+        let event = ctx.props().event.clone();
+        let onclick_close = ctx.props().agenda_link.callback(move |_| AgendaMsg::AppMsg(AppMsg::SetPage(Page::Popup(PopupState::Closing { week_day, event: event.clone(), popup_size: None }))));
         let event_color = COLORS.get(&ctx.props().event.summary);
         let summary = &ctx.props().event.summary;
         let name = ctx.props().event.format_name();

--- a/src/popup/popup.rs
+++ b/src/popup/popup.rs
@@ -2,16 +2,16 @@ use crate::{prelude::*, slider::width};
 
 #[derive(Clone, PartialEq)]
 pub enum PopupState {
-    Opened { week_day: u8, event: Rc<RawEvent>, popup_size: Option<usize> },
-    Closing { week_day: u8, event: Rc<RawEvent>, popup_size: Option<usize> },
+    Opened { week_day: u8, event: RawEvent, popup_size: Option<usize> },
+    Closing { week_day: u8, event: RawEvent, popup_size: Option<usize> },
     Closed,
 }
 
 impl PopupState {
-    pub fn as_option(&self) -> Option<(u8, Rc<RawEvent>, Option<usize>)> {
+    pub fn as_option(&self) -> Option<(u8, &RawEvent, Option<usize>)> {
         match self {
-            PopupState::Opened { week_day, event, popup_size } => Some((*week_day, Rc::clone(event), *popup_size)),
-            PopupState::Closing { week_day, event, popup_size } => Some((*week_day, Rc::clone(event), *popup_size)),
+            PopupState::Opened { week_day, event, popup_size } => Some((*week_day, event, *popup_size)),
+            PopupState::Closing { week_day, event, popup_size } => Some((*week_day, event, *popup_size)),
             PopupState::Closed => None,
         }
     }
@@ -25,7 +25,7 @@ pub enum PopupMsg {
 
 #[derive(Properties, Clone)]
 pub struct PopupProps {
-    pub event: Rc<RawEvent>,
+    pub event: RawEvent,
     pub week_day: u8,
     pub agenda_link: Scope<Agenda>,
 }

--- a/src/popup/popup.rs
+++ b/src/popup/popup.rs
@@ -1,22 +1,5 @@
 use crate::{prelude::*, slider::width};
 
-#[derive(Clone, PartialEq)]
-pub enum PopupState {
-    Opened { week_day: u8, event: RawEvent, popup_size: Option<usize> },
-    Closing { week_day: u8, event: RawEvent, popup_size: Option<usize> },
-    Closed,
-}
-
-impl PopupState {
-    pub fn as_option(&self) -> Option<(u8, &RawEvent, Option<usize>)> {
-        match self {
-            PopupState::Opened { week_day, event, popup_size } => Some((*week_day, event, *popup_size)),
-            PopupState::Closing { week_day, event, popup_size } => Some((*week_day, event, *popup_size)),
-            PopupState::Closed => None,
-        }
-    }
-}
-
 pub struct Popup {}
 
 pub enum PopupMsg {

--- a/src/popup/popup.rs
+++ b/src/popup/popup.rs
@@ -1,5 +1,6 @@
 use crate::{prelude::*, slider::width};
 
+#[derive(Clone, PartialEq)]
 pub enum PopupState {
     Opened { week_day: u8, event: Rc<RawEvent>, popup_size: Option<usize> },
     Closing { week_day: u8, event: Rc<RawEvent>, popup_size: Option<usize> },
@@ -66,7 +67,7 @@ impl Component for Popup {
     }
 
     fn view(&self, ctx: &Context<Self>) -> Html {
-        let onclick_close = ctx.props().agenda_link.callback(|_| AgendaMsg::ClosePopup);
+        let onclick_close = ctx.props().agenda_link.callback(|_| AgendaMsg::AppMsg(AppMsg::ClosePopup));
         let event_color = COLORS.get(&ctx.props().event.summary);
         let summary = &ctx.props().event.summary;
         let name = ctx.props().event.format_name();

--- a/src/popup/popup.rs
+++ b/src/popup/popup.rs
@@ -26,13 +26,12 @@ pub enum PopupMsg {
 #[derive(Properties, Clone)]
 pub struct PopupProps {
     pub event: RawEvent,
-    pub week_day: u8,
     pub agenda_link: Scope<Agenda>,
 }
 
 impl PartialEq for PopupProps {
     fn eq(&self, other: &Self) -> bool {
-        self.event == other.event && self.week_day == other.week_day
+        self.event == other.event
     }
 }
 
@@ -67,9 +66,7 @@ impl Component for Popup {
     }
 
     fn view(&self, ctx: &Context<Self>) -> Html {
-        let week_day = ctx.props().week_day;
-        let event = ctx.props().event.clone();
-        let onclick_close = ctx.props().agenda_link.callback(move |_| AgendaMsg::AppMsg(AppMsg::SetPage(Page::Popup(PopupState::Closing { week_day, event: event.clone(), popup_size: None }))));
+        let onclick_close = ctx.props().agenda_link.callback(move |_| AgendaMsg::AppMsg(AppMsg::SetPage(Page::Agenda)));
         let event_color = COLORS.get(&ctx.props().event.summary);
         let summary = &ctx.props().event.summary;
         let name = ctx.props().event.format_name();

--- a/src/slider.rs
+++ b/src/slider.rs
@@ -47,7 +47,7 @@ impl SliderManager {
         let slider2 = Rc::clone(&slider);
         let link2 = link;
         let resize = Closure::wrap(Box::new(move |_: web_sys::Event| {
-            link2.send_message(AgendaMsg::AppMsg(AppMsg::ClosePopup));
+            // TODO link2.send_message(AgendaMsg::AppMsg(AppMsg::ClosePopup));
             let mut slider = match slider2.try_borrow_mut() {
                 Ok(slider) => slider,
                 Err(_) => {

--- a/src/slider.rs
+++ b/src/slider.rs
@@ -47,7 +47,7 @@ impl SliderManager {
         let slider2 = Rc::clone(&slider);
         let link2 = link;
         let resize = Closure::wrap(Box::new(move |_: web_sys::Event| {
-            // TODO link2.send_message(AgendaMsg::AppMsg(AppMsg::ClosePopup));
+            link2.send_message(AgendaMsg::AppMsg(AppMsg::SetPage(Page::Agenda)));
             let mut slider = match slider2.try_borrow_mut() {
                 Ok(slider) => slider,
                 Err(_) => {

--- a/src/slider.rs
+++ b/src/slider.rs
@@ -47,7 +47,7 @@ impl SliderManager {
         let slider2 = Rc::clone(&slider);
         let link2 = link;
         let resize = Closure::wrap(Box::new(move |_: web_sys::Event| {
-            link2.send_message(AgendaMsg::ClosePopup);
+            link2.send_message(AgendaMsg::AppMsg(AppMsg::ClosePopup));
             let mut slider = match slider2.try_borrow_mut() {
                 Ok(slider) => slider,
                 Err(_) => {


### PR DESCRIPTION
Previously, the event popup was considered as something inside the agenda component. This allowed some complex animation code, but was inconsistent for the user. Indeed, the address in the url was still /agenda, and pressing back didn't close the popup.